### PR TITLE
Prevent onLoad callback execution if component is unmounting

### DIFF
--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -32,7 +32,13 @@ class CKEditor extends React.Component {
     }
   }
 
-  onLoad(){
+  componentWillUnmount() {
+    this.unmounting = true;
+  }
+
+  onLoad() {
+    if (this.unmounting) return;
+
     this.setState({
       isScriptLoaded: true
     });


### PR DESCRIPTION
onLoad callback execution in an unmounted component causes React errors, for example when reloading the page. This fixes the issue.