### PR TITLE
do an automatic reload when ckeditor has not been loaded.

### DIFF
--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -36,6 +36,13 @@ class CKEditor extends React.Component {
     this.unmounting = true;
   }
 
+  reloadEditor() {
+    clearTimeout(this.timeout);
+    if (!this.editorInstance.ui.editor.loaded) {
+      loadScript(this.props.scriptUrl, this.onLoad);
+    }
+  }
+
   onLoad() {
     if (this.unmounting) return;
 
@@ -60,6 +67,8 @@ class CKEditor extends React.Component {
 
       this.editorInstance.on(event, eventHandler);
     }
+
+    this.timeout = setTimeout(this.reloadEditor.bind(this), 3000);
   }
 
   render() {


### PR DESCRIPTION
We found this issue when using react-ckeditor-component in our app.

When browser first visits our page, with no cache etc. ckeditor doesn't gets rendered. We can see this error in the console: CKEditor Uncaught TypeError: Cannot call method 'unselectable' of null.

Not sure why, however, it feels like ckeditor throws that error during its editor instance initialization.

You can very reliably reproduce this issue in Internet Explorer 11, by clearing browser history.

My current solution is to have a 3-second delayed check on the editorinstance and if the editor ui failed to initialize after 3 seconds. we false loadscript process again. Only this time, ckeditor.js is loaded already in the dom.

