### PR TITLE
Remove CKEditor instance on unmount

### DIFF
--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -25,15 +25,19 @@ class CKEditor extends React.Component {
 
   //load ckeditor script as soon as component mounts if not already loaded
   componentDidMount() {
-    if(!this.props.isScriptLoaded){
+    if (!this.props.isScriptLoaded) {
       loadScript(this.props.scriptUrl, this.onLoad);
-    }else{
+    } else {
       this.onLoad();
     }
   }
 
   componentWillUnmount() {
     this.unmounting = true;
+    if (this.editorInstance) {
+      this.editorInstance.removeAllListeners();
+      window.CKEDITOR.remove(this.editorInstance);
+    }
   }
 
   onLoad() {
@@ -69,7 +73,7 @@ class CKEditor extends React.Component {
     */
 
     //Register listener for custom events if any
-    for(var event in this.props.events){
+    for (var event in this.props.events) {
       var eventHandler = this.props.events[event];
 
       this.editorInstance.on(event, eventHandler);

--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -92,7 +92,7 @@ class CKEditor extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    this.registerEventHandlers(nextProps.events, this.props.events);
+    if (this.editorInstance) this.registerEventHandlers(nextProps.events, this.props.events);
   }
 
   render() {

--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -15,6 +15,7 @@ class CKEditor extends React.Component {
 
     //Bindings
     this.onLoad = this.onLoad.bind(this);
+    this.registerEventHandlers = this.registerEventHandlers.bind(this);
 
     //State initialization
     this.state = {
@@ -72,12 +73,26 @@ class CKEditor extends React.Component {
     });
     */
 
-    //Register listener for custom events if any
-    for (var event in this.props.events) {
-      var eventHandler = this.props.events[event];
+    this.registerEventHandlers(this.props.events);
+  }
 
-      this.editorInstance.on(event, eventHandler);
+  registerEventHandlers(events, prevEvents) {
+    prevEvents = prevEvents || {};
+
+    //Register listener for custom events if any
+    for (var event in events) {
+      if (events[event] !== prevEvents[event]) {
+        var prevEventHandler = prevEvents[event];
+        if (prevEventHandler) this.editorInstance.removeListener(event, prevEventHandler);
+
+        var eventHandler = events[event];
+        this.editorInstance.on(event, eventHandler);
+      }
     }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.registerEventHandlers(nextProps.events, this.props.events);
   }
 
   render() {


### PR DESCRIPTION
Seems to fix the sometimes appearing "Uncaught TypeError: Cannot call method 'unselectable' of null" errors