### PR TITLE
Don't update content if it is undefined

### DIFF
--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -33,7 +33,7 @@ class CKEditor extends React.Component {
 
   componentWillReceiveProps(props) {
     const editor = this.editorInstance;
-    if (editor && editor.getData() !== props.content) {
+    if (props.content !== undefined && editor && editor.getData() !== props.content) {
       editor.setData(props.content);
     }
   }


### PR DESCRIPTION
Hello,

Thanks for the great plugin !

## The problem
In the current state, if content prop is undefined, the editor would reset his content on every update. 

## The solution
Check if content prop is defined before updating editor data.

## Why do we want that ?
(I don't want the editor to be fully controlled because it will cause a lot of useless renders and a lot of calls to getData(), I prefer to update my content on `blur` event

## Notes
If someone needs to reset the editor he can pass an empty string to the content prop.