### PR TITLE
Update ckeditor.js to prevent XSS vulnerability

### DIFF
--- a/src/ckeditor.js
+++ b/src/ckeditor.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 const loadScript = require('load-script');
 
-var defaultScriptUrl = 'https://cdn.ckeditor.com/4.6.2/standard/ckeditor.js';
+var defaultScriptUrl = 'https://cdn.ckeditor.com/4.12.1/standard/ckeditor.js';
 
 /**
  * @author codeslayer1


### PR DESCRIPTION
For CKEditor 4.6.2 version, XSS vulnerability is there: https://snyk.io/vuln/npm:ckeditor@4.6.2
So changing defaultScriptUrl from https://cdn.ckeditor.com/4.6.2/standard/ckeditor.js to  https://cdn.ckeditor.com/4.12.1/standard/ckeditor.js